### PR TITLE
Uses hardcoded value for default branch name

### DIFF
--- a/.github/workflows/on-default.yml
+++ b/.github/workflows/on-default.yml
@@ -3,7 +3,8 @@ name: Default branch verification
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches:
+      - master
 
 jobs:
 


### PR DESCRIPTION
Macros $default-branch turned out not to be working in on: push: branches: $default-branch